### PR TITLE
Fix Updating ControlNet Properties

### DIFF
--- a/frontends/krita/krita_comfy/pages/controlnet.py
+++ b/frontends/krita/krita_comfy/pages/controlnet.py
@@ -161,7 +161,7 @@ class ControlNetUnitSettings(QWidget):
         if value is not None:
             widget.qspin.setValue(value)
         widget.qspin.valueChanged.connect(
-            lambda value: self.set_input(inputs, key, value)
+            lambda value: self.set_input(dict(script.cfg(f"controlnet{self.unit}_inputs", dict)), key, value)
         )
         self.set_input(inputs, key, widget.qspin.value())
         self.preprocessor_settings_layout.addLayout(widget)
@@ -174,7 +174,7 @@ class ControlNetUnitSettings(QWidget):
             widget.qcombo.setEditText(value)
         widget.qcombo.addItems(options)
         widget.qcombo.editTextChanged.connect(
-            lambda value: self.set_input(inputs, key, value)
+            lambda value: self.set_input(dict(script.cfg(f"controlnet{self.unit}_inputs", dict)), key, value)
         )
         self.set_input(inputs, key, widget.qcombo.currentText())
         self.preprocessor_settings_layout.addLayout(widget)


### PR DESCRIPTION
Issue:
In the lamba assigned to the slot 'widget.qcombo.editTextChanged.connect' We take a copy of the default config into the lambda here: 'lambda value: self.set_input(>>inputs<<, key, value)' This mean we are only able to change one property at a time as the other are reset to the default.

Fix:
We need to get the current config inside the lamba before we modify and update it. not sure if this is the most optimal fix but it does fix the issue.

after a18dcab the issue is a little different braking the case completely without resetting all the options

Steps to repro:
1. open control net
2. switch to openpose
3. set hands and face to disabled
4. update version to 1.1
5. Get Bad Case: a18dcab
6. go back and update hands and face
7. works.


Bad Case: 9019de9
update: detect_hand to:disable
{'coarse': 'disable', 'detect_body': 'enable', 'detect_face': 'enable', 'detect_hand': 'disable', 'max_faces': 10, 'min_confidence': 0.5, 'safe': 'enable', 'threshold': 0, 'version': 'v1'} update: detect_face to:disable
{'coarse': 'disable', 'detect_body': 'enable', 'detect_face': 'disable', 'detect_hand': 'enable', 'max_faces': 10, 'min_confidence': 0.5, 'safe': 'enable', 'threshold': 0, 'version': 'v1'}

Bad Case: a18dcab
Comfy-UI:
got prompt
Failed to validate prompt for output SaveImage:
* OpenposePreprocessor OpenposePreprocessor:
  - Required input is missing: detect_hand
  - Required input is missing: version
