### PR TITLE
Add Lora text to prompt info

### DIFF
--- a/frontends/krita/krita_comfy/client.py
+++ b/frontends/krita/krita_comfy/client.py
@@ -221,7 +221,7 @@ class Client(QObject):
                     output += f"\n<lora:{lora_name}:{lora_weight}>"
                     lora_loader_count += 1
                     node_inputs = nodes[f"{node_name}+{lora_loader_count}"]["inputs"]
-            except KeyError:
+            except (KeyError, ValueError, IndexError):
                 return output
 
         def craft_response(images, history, names):

--- a/frontends/krita/krita_comfy/client.py
+++ b/frontends/krita/krita_comfy/client.py
@@ -215,13 +215,12 @@ class Client(QObject):
             try:
                 nodes = history["prompt"][2]
                 node_inputs = nodes[f"{node_name}+{lora_loader_count}"]["inputs"]
-                while node_inputs is not None:
+                while True:
                     lora_name = node_inputs["lora_name"]
                     lora_weight = node_inputs["strength_model"]
                     output += f"\n<lora:{lora_name}:{lora_weight}>"
                     lora_loader_count += 1
                     node_inputs = nodes[f"{node_name}+{lora_loader_count}"]["inputs"]
-                return output
             except KeyError:
                 return output
 


### PR DESCRIPTION
Issue:
The text that is saved to the layer name has the lora removed

Fix:
Walk the API request and re-add the lora to the positive prompt

Notes:
I don't know if there is a way to get the original prompt strings for the request but that would be ideal.