### PR TITLE
Scale ControlNet Preview

### DIFF
--- a/frontends/krita/krita_comfy/pages/controlnet.py
+++ b/frontends/krita/krita_comfy/pages/controlnet.py
@@ -79,7 +79,7 @@ class ControlNetUnitSettings(QWidget):
 
         self.image_loader = ImageLoaderLayout()
         input_image = script.cfg(f"controlnet{self.unit}_input_image", str)
-        self.image_loader.preview.setPixmap(
+        self.image_loader.set_pixmap(
             QPixmap.fromImage(b64_to_img(input_image) if input_image else QImage())
         )
 
@@ -121,6 +121,7 @@ class ControlNetUnitSettings(QWidget):
         #Preview annotator
         self.annotator_preview = QLabel()
         self.annotator_preview.setAlignment(Qt.AlignCenter)
+        self.annotator_preview.setMinimumWidth(256)
         self.annotator_preview_button = QPushButton("Preview annotator")
         self.annotator_clear_button = QPushButton("Clear preview")
         self.copy_result_button = QPushButton("Copy result to clipboard")
@@ -228,7 +229,7 @@ class ControlNetUnitSettings(QWidget):
             script.action_update_controlnet_config()
 
     def image_loaded(self):
-        image = self.image_loader.preview.pixmap().toImage().convertToFormat(QImage.Format_RGBA8888)
+        image = self.image_loader.get_pixmap().toImage().convertToFormat(QImage.Format_RGBA8888)
         script.cfg.set(f"controlnet{self.unit}_input_image", img_to_b64(image)) 
 
     def annotator_preview_received(self, pixmap):

--- a/frontends/krita/krita_comfy/widgets/image_loader.py
+++ b/frontends/krita/krita_comfy/widgets/image_loader.py
@@ -5,11 +5,13 @@ class ImageLoaderLayout(QVBoxLayout):
     def __init__(self, *args, **kwargs):
         super(ImageLoaderLayout, self).__init__(*args, **kwargs)
 
-        self.preview = QLabel()
-        self.preview.setAlignment(Qt.AlignCenter)
+        self.scaled_preview = QLabel()
+        self.scaled_preview.setAlignment(Qt.AlignCenter)
+        self.scaled_preview.setMinimumWidth(256)
         self.import_button = QPushButton('Import image')
         self.paste_button = QPushButton('Paste image')
         self.clear_button = QPushButton('Clear')
+        self.original_pixmap = QPixmap()
 
         button_layout = QHBoxLayout()
         button_layout.addWidget(self.import_button)
@@ -17,32 +19,35 @@ class ImageLoaderLayout(QVBoxLayout):
 
         self.addLayout(button_layout)
         self.addWidget(self.clear_button)
-        self.addWidget(self.preview)
+        self.addWidget(self.scaled_preview)
 
         self.import_button.released.connect(self.load_image)
         self.paste_button.released.connect(self.paste_image)
         self.clear_button.released.connect(self.clear_image)
 
+    def get_pixmap(self):
+        return self.original_pixmap
+
+    def set_pixmap(self, pixmap):
+        # store the full size pixmap
+        self.original_pixmap = pixmap
+        max_width = self.scaled_preview.width()
+        if pixmap.width() > max_width:
+            pixmap = pixmap.scaledToWidth(max_width, Qt.SmoothTransformation)
+        self.scaled_preview.setPixmap(pixmap)
+
     def load_image(self):
         file_name, _ = QFileDialog.getOpenFileName(self.import_button, 'Open File', '', 'Image Files (*.png *.jpg *.bmp)')
         if file_name:
             pixmap = QPixmap(file_name)
-
-            if pixmap.width() > self.preview.width():
-                pixmap = pixmap.scaledToWidth(self.preview.width(), Qt.SmoothTransformation)
-                
-            self.preview.setPixmap(pixmap)
+            self.set_pixmap(pixmap)
 
     def paste_image(self):
         pixmap = QPixmap(QApplication.clipboard().pixmap())
-
-        if pixmap.width() > self.preview.width():
-            pixmap = pixmap.scaledToWidth(self.preview.width(), Qt.SmoothTransformation)
-
-        self.preview.setPixmap(pixmap)
+        self.set_pixmap(pixmap)
 
     def clear_image(self):
-        self.preview.setPixmap(QPixmap())
+        self.set_pixmap(QPixmap())
 
 
         


### PR DESCRIPTION
Issue:
ControlNet previews are 1:1 which is fine for small selections.
 When they increase in size making the dialog difficult to navigate

Fix:
Rename QLabel preview -> scaled_preview to break all private accesses.
Add ImageLoaderLayout.original_pixmap and get_pixmap to obtain the unscaled result.
Add set_pixmap to better share all the scaling code. 
set a minimum width on the Qlable to allow it to shrink. 
same for controlnet annotator_preview
Update controlnet.py to use set/get_pixmap