### PR TITLE
Prepend paths to known Lora

### DIFF
--- a/frontends/krita/krita_comfy/client.py
+++ b/frontends/krita/krita_comfy/client.py
@@ -449,8 +449,9 @@ class Client(QObject):
         return params
 
     def auto_complete_LoRA(self, name: str):
-        lora_list = [ l.removesuffix(".safetensors") for l in self.cfg("sd_lora_list", str)]
-        viable_loras = [l for l in lora_list if l.endswith(name)]
+        lora_list = [ re.sub(".safetensors$", "", l, flags=re.I) for l in self.cfg("sd_lora_list", str)]
+        viable_loras = [l for l in lora_list if re.search(name+"$", l, flags=re.I)]
+        print(viable_loras)
         if (len(viable_loras) == 1 and name == viable_loras[0]):
             return name
         elif (len(viable_loras) == 1):
@@ -488,6 +489,7 @@ class Client(QObject):
             for match in matches:
                 # Extract the lora name and the strength number from the match
                 lora_name = self.auto_complete_LoRA(match[0])
+                print(lora_name)
                 strength_number = float(match[1])
 
                 # Create a node dictionary with the class type, inputs, and outputs

--- a/frontends/krita/krita_comfy/client.py
+++ b/frontends/krita/krita_comfy/client.py
@@ -219,9 +219,9 @@ class Client(QObject):
                 while True:
                     lora_name = re.sub(".safetensors", "", node_inputs["lora_name"])
                     lora_weight = node_inputs["strength_model"]
-                    #Let's not use "<" and ">" signs here since the content between it will be totally removed somewhere during
-                    #Group later name setting. Trying to escape characters didn't seem to work, so let's just list the loras.
-                    output += f" lora:{lora_name}:{lora_weight}" 
+                    # < > are hidden from the lable names but are still in the string
+                    # I think krita is trying to hide XML from the user
+                    output += f"\n<lora:{lora_name}:{lora_weight}>"
                     lora_loader_count += 1
                     node_inputs = nodes[f"{node_name}+{lora_loader_count}"]["inputs"]
             except (KeyError, ValueError, IndexError):
@@ -448,6 +448,20 @@ class Client(QObject):
 
         return params
 
+    def auto_complete_LoRA(self, name: str):
+        lora_list = [ l.removesuffix(".safetensors") for l in self.cfg("sd_lora_list", str)]
+        viable_loras = [l for l in lora_list if l.endswith(name)]
+        if (len(viable_loras) == 1 and name == viable_loras[0]):
+            return name
+        elif (len(viable_loras) == 1):
+            print("Using Lora:", viable_loras[0])
+            return viable_loras[0]
+        elif (len(viable_loras) > 1):
+            print("Ambiguous Lora:", name, "\nCould be:", viable_loras )
+        return name
+
+
+
     def loadLoRAs(self, params, mode, connect_last_lora_outputs = True):
         clipsetlastlayer_id = DEFAULT_NODE_IDS["ClipSetLastLayer"]
         checkpointloadersimple_id = DEFAULT_NODE_IDS["CheckpointLoaderSimple"]
@@ -464,7 +478,7 @@ class Client(QObject):
             pos_prompt = self.cfg(f"{mode}_prompt", str)
 
             # Use a regular expression to find all the elements between < and > in the string
-            pattern = r"<lora:([=\[\] /\w\d.-]+):([\d.]+)>"
+            pattern = r"<lora:([=\[\] /\w\d.-]+):(\-?[\d.]+)>"
             matches = re.findall(pattern, pos_prompt)
 
             # Remove LoRAs from prompt
@@ -473,7 +487,7 @@ class Client(QObject):
             # Loop through the matches and create a node for each element
             for match in matches:
                 # Extract the lora name and the strength number from the match
-                lora_name = match[0]
+                lora_name = self.auto_complete_LoRA(match[0])
                 strength_number = float(match[1])
 
                 # Create a node dictionary with the class type, inputs, and outputs
@@ -516,10 +530,10 @@ class Client(QObject):
                     #Connect KSampler for upscale (second pass) to last lora node if found.
                     if ksampler_upscale_id in params:
                         params[ksampler_upscale_id]["inputs"]["model"] = [last_lora_id, 0]
-                
+
                     #Connect positive prompt to lora clip.
                     params[cliptextencode_pos_id]["inputs"]["clip"] = [last_lora_id, 1]
-                    
+
                     #Connect negative prompt to lora clip.
                     params[cliptextencode_neg_id]["inputs"]["clip"] = [last_lora_id, 1]
 
@@ -958,13 +972,18 @@ class Client(QObject):
                 node = obj["VAELoader"]["input"]["required"]
                 self.cfg.set("sd_vae_list", ["None"] + node["vae_name"][0])
 
-            if check_response(obj, ["LatentUpscale", "UpscaleModelLoader", 
+            def get_loras():
+                node = obj["LoraLoader"]["input"]["required"]
+                self.cfg.set("sd_lora_list", node["lora_name"][0])
+
+            if check_response(obj, ["LatentUpscale", "UpscaleModelLoader",
                         "KSampler", "CheckpointLoaderSimple", 
-                        "VAELoader", "ControlNetLoader", "CLIPVisionLoader"]):
+                        "VAELoader", "ControlNetLoader", "CLIPVisionLoader", "LoraLoader"]):
                 get_upscalers()
                 get_upscaler_models()
                 get_sampler_data()
                 get_models()
+                get_loras()
                 get_VAE()
                 self.set_controlnet_preprocessor_and_model_list(obj)
 
@@ -1025,7 +1044,7 @@ class Client(QObject):
         loras_loaded = False
 
         def remove_lora_from_prompt():
-            pattern = r"<lora:([=\[\] /\w\d.-]+):([\d.]+)>"
+            pattern = r"<lora:([=\[\] /\w\d.-]+):(\-?[\d.]+)>"
             return re.sub(pattern, "", prompt)
 
         def load_placeholder_data():
@@ -1066,7 +1085,7 @@ class Client(QObject):
                     loras_loaded = True
 
             return json.loads(str_params) if str_params != "" else params
-        
+
         if model_loader_found:
             params[model_loader_id]["inputs"]["ckpt_name"] = self.cfg("sd_model", str)
 

--- a/frontends/krita/krita_comfy/client.py
+++ b/frontends/krita/krita_comfy/client.py
@@ -170,6 +170,8 @@ class Client(QObject):
     images_received = pyqtSignal(object)
     prompt_sent = pyqtSignal()
 
+    lora_re = r"<lora:([=\[\] \\/\w\d.-]+):(\-?[\d.]+)>"
+
     def __init__(self, cfg: Config, ext_cfg: Config):
         """It is highly dependent on config's structure to the point it writes directly to it. :/"""
         super(Client, self).__init__()
@@ -478,8 +480,7 @@ class Client(QObject):
             pos_prompt = self.cfg(f"{mode}_prompt", str)
 
             # Use a regular expression to find all the elements between < and > in the string
-            pattern = r"<lora:([=\[\] /\w\d.-]+):(\-?[\d.]+)>"
-            matches = re.findall(pattern, pos_prompt)
+            matches = re.findall(self.lora_re, pos_prompt)
 
             # Remove LoRAs from prompt
             params[cliptextencode_pos_id]["inputs"]["text"] = re.sub(pattern, "", pos_prompt)
@@ -1044,7 +1045,7 @@ class Client(QObject):
         loras_loaded = False
 
         def remove_lora_from_prompt():
-            pattern = r"<lora:([=\[\] /\w\d.-]+):(\-?[\d.]+)>"
+            pattern = self.lora_re
             return re.sub(pattern, "", prompt)
 
         def load_placeholder_data():

--- a/frontends/krita/krita_comfy/client.py
+++ b/frontends/krita/krita_comfy/client.py
@@ -451,7 +451,6 @@ class Client(QObject):
     def auto_complete_LoRA(self, name: str):
         lora_list = [ re.sub(".safetensors$", "", l, flags=re.I) for l in self.cfg("sd_lora_list", str)]
         viable_loras = [l for l in lora_list if re.search(name+"$", l, flags=re.I)]
-        print(viable_loras)
         if (len(viable_loras) == 1 and name == viable_loras[0]):
             return name
         elif (len(viable_loras) == 1):
@@ -489,7 +488,6 @@ class Client(QObject):
             for match in matches:
                 # Extract the lora name and the strength number from the match
                 lora_name = self.auto_complete_LoRA(match[0])
-                print(lora_name)
                 strength_number = float(match[1])
 
                 # Create a node dictionary with the class type, inputs, and outputs

--- a/frontends/krita/krita_comfy/client.py
+++ b/frontends/krita/krita_comfy/client.py
@@ -483,7 +483,7 @@ class Client(QObject):
             matches = re.findall(self.lora_re, pos_prompt)
 
             # Remove LoRAs from prompt
-            params[cliptextencode_pos_id]["inputs"]["text"] = re.sub(pattern, "", pos_prompt)
+            params[cliptextencode_pos_id]["inputs"]["text"] = re.sub(self.lora_re, "", pos_prompt)
 
             # Loop through the matches and create a node for each element
             for match in matches:

--- a/frontends/krita/krita_comfy/defaults.py
+++ b/frontends/krita/krita_comfy/defaults.py
@@ -123,6 +123,7 @@ class Defaults:
 
     sd_model_list: List[str] = field(default_factory=lambda: [ERROR_MSG])
     sd_model: str = "model.ckpt"
+    sd_lora_list: List[str] = field(default_factory=lambda: [ERROR_MSG])
     sd_vae_list: List[str] = field(default_factory=lambda: [ERROR_MSG])
     sd_vae: str = "Automatic"
     clip_skip: int = 1


### PR DESCRIPTION
Issue:
SD automatic uses the name only lora format
<lora:people_count_slider_v1:0.5>
Comfy uses the full path
<lora:OstrisUtils/people_count_slider_v1:0.5>

Fix:
We collect all the know loras from the server on startup Then we attempt to match the lora name to the known lora paths when creating the workflow. This allows for use of the same lora format as SD automatic if there are multiple loras that could match we use the original string.

- Updated Lora regex to allow for negative weights.