### PR TITLE
Use PyQt5 imports

### DIFF
--- a/frontends/krita/krita_comfy/__init__.py
+++ b/frontends/krita/krita_comfy/__init__.py
@@ -1,5 +1,4 @@
 from krita import DockWidgetFactory, DockWidgetFactoryBase, Krita
-
 from .defaults import (
     TAB_CONFIG,
     TAB_IMG2IMG,

--- a/frontends/krita/krita_comfy/client.py
+++ b/frontends/krita/krita_comfy/client.py
@@ -2,22 +2,16 @@ import json
 import socket
 import uuid
 import re
+import ssl
 from math import ceil, floor
 from random import randint
 from typing import Any
 from urllib.error import URLError
 from urllib.parse import urljoin, urlparse, urlencode
 from urllib.request import Request, urlopen
-import ssl
 
-from krita import (
-    Qt,
-    QImage,
-    QObject,
-    QThread,
-    pyqtSignal,
-    QTimer
-)
+from PyQt5.QtGui import QImage
+from PyQt5.QtCore import QObject, QThread, pyqtSignal, QTimer
 
 from .config import Config
 from .defaults import (

--- a/frontends/krita/krita_comfy/config.py
+++ b/frontends/krita/krita_comfy/config.py
@@ -1,7 +1,7 @@
 from dataclasses import asdict
 from typing import Any
 
-from krita import QObject, QReadWriteLock, QSettings
+from PyQt5.QtCore import QObject, QReadWriteLock, QSettings
 
 from .defaults import CFG_FOLDER, CFG_NAME, DEFAULTS, ERR_MISSING_CONFIG
 

--- a/frontends/krita/krita_comfy/docker.py
+++ b/frontends/krita/krita_comfy/docker.py
@@ -1,4 +1,5 @@
-from krita import DockWidget, QScrollArea
+from krita import DockWidget
+from PyQt5.QtWidgets import QScrollArea
 
 from .script import script
 from .style import style

--- a/frontends/krita/krita_comfy/extension.py
+++ b/frontends/krita/krita_comfy/extension.py
@@ -1,4 +1,7 @@
-from krita import Extension, QMainWindow, QTimer
+from krita import Extension
+
+from PyQt5.QtWidgets import QMainWindow
+from PyQt5.QtCore import QTimer
 
 from .defaults import REFRESH_INTERVAL
 from .script import script

--- a/frontends/krita/krita_comfy/pages/common.py
+++ b/frontends/krita/krita_comfy/pages/common.py
@@ -1,4 +1,4 @@
-from krita import QHBoxLayout, QPushButton, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QHBoxLayout, QPushButton, QVBoxLayout, QWidget
 
 from ..script import script
 from ..widgets import QCheckBox, QComboBoxLayout, QLabel, QSpinBoxLayout

--- a/frontends/krita/krita_comfy/pages/config.py
+++ b/frontends/krita/krita_comfy/pages/config.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from krita import QHBoxLayout, QLineEdit, QPushButton, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QHBoxLayout, QLineEdit, QPushButton, QVBoxLayout, QWidget
 
 from ..defaults import DEFAULTS
 from ..script import script

--- a/frontends/krita/krita_comfy/pages/controlnet.py
+++ b/frontends/krita/krita_comfy/pages/controlnet.py
@@ -1,15 +1,9 @@
-from krita import (
-    QApplication, 
-    QPixmap, 
-    QImage, 
-    QPushButton, 
-    QWidget, 
-    QVBoxLayout, 
-    QHBoxLayout, 
-    QStackedLayout, 
-    Qt
-)
 from functools import partial
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPixmap, QImage
+from PyQt5.QtWidgets import QApplication, QPushButton, QWidget, QVBoxLayout, QHBoxLayout, QStackedLayout
+
 from ..script import script
 from ..widgets import (
     QLabel, 
@@ -21,6 +15,7 @@ from ..widgets import (
     QSpinBoxLayout
 )
 from ..utils import img_to_b64, b64_to_img, clear_layout
+
 
 class ControlNetPage(QWidget):                                                      
     name = "ControlNet"
@@ -65,6 +60,7 @@ class ControlNetPage(QWidget):
 
         self.controlnet_unit.qcombo.currentTextChanged.connect(self.controlnet_unit_changed)
         script.status_changed.connect(lambda s: self.status_bar.set_status(s))
+
 
 class ControlNetUnitSettings(QWidget):    
     def __init__(self, cfg_unit_number: int = 0, *args, **kwargs):

--- a/frontends/krita/krita_comfy/pages/extension.py
+++ b/frontends/krita/krita_comfy/pages/extension.py
@@ -2,7 +2,7 @@ import json
 from functools import partial
 from typing import List
 
-from krita import QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QVBoxLayout, QWidget
 
 from ..config import Config
 from ..script import script

--- a/frontends/krita/krita_comfy/pages/img2img.py
+++ b/frontends/krita/krita_comfy/pages/img2img.py
@@ -1,4 +1,4 @@
-from krita import QPushButton
+from PyQt5.QtWidgets import QPushButton
 
 from ..script import script
 from ..widgets import TipsLayout

--- a/frontends/krita/krita_comfy/pages/img_base.py
+++ b/frontends/krita/krita_comfy/pages/img_base.py
@@ -1,4 +1,4 @@
-from krita import QHBoxLayout, QVBoxLayout, QWidget, QPushButton
+from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout, QWidget, QPushButton
 
 from ..script import script
 from ..widgets import (

--- a/frontends/krita/krita_comfy/pages/inpaint.py
+++ b/frontends/krita/krita_comfy/pages/inpaint.py
@@ -1,9 +1,10 @@
-from krita import QHBoxLayout, QPushButton
+from PyQt5.QtWidgets import QHBoxLayout, QPushButton
 
 from ..script import script
 from ..widgets import QCheckBox, QComboBoxLayout, TipsLayout
 from .img_base import SDImgPageBase
 from ..utils import get_workflow
+
 
 class InpaintPage(SDImgPageBase):
     name = "Inpaint"

--- a/frontends/krita/krita_comfy/pages/preview.py
+++ b/frontends/krita/krita_comfy/pages/preview.py
@@ -1,4 +1,5 @@
-from krita import QPixmap, QPushButton, QVBoxLayout, QWidget
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtWidgets import QPushButton, QVBoxLayout, QWidget
 
 from ..script import script
 from ..utils import b64_to_img

--- a/frontends/krita/krita_comfy/pages/txt2img.py
+++ b/frontends/krita/krita_comfy/pages/txt2img.py
@@ -1,9 +1,9 @@
-from krita import QHBoxLayout, QPushButton
-
+from PyQt5.QtWidgets import QHBoxLayout, QPushButton
 from ..script import script
 from ..widgets import TipsLayout
 from .img_base import SDImgPageBase
 from ..utils import get_workflow
+
 
 class Txt2ImgPage(SDImgPageBase):
     name = "Txt2Img"

--- a/frontends/krita/krita_comfy/pages/upscale.py
+++ b/frontends/krita/krita_comfy/pages/upscale.py
@@ -1,4 +1,4 @@
-from krita import QPushButton, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QPushButton, QVBoxLayout, QWidget
 
 from ..script import script
 from ..widgets import (

--- a/frontends/krita/krita_comfy/pages/workflow.py
+++ b/frontends/krita/krita_comfy/pages/workflow.py
@@ -1,16 +1,14 @@
 import json
-from krita import (
-    QWidget,
-    QPushButton,
-    QVBoxLayout,
-    QFileDialog
-)
-from ..widgets import(
+
+from PyQt5.QtWidgets import QWidget, QPushButton, QVBoxLayout, QFileDialog
+
+from ..widgets import (
     StatusBar,
     QComboBoxLayout,
     QPromptEdit
 )
 from ..script import script
+
 
 class WorkflowPage(QWidget):
     name = "Workflow"

--- a/frontends/krita/krita_comfy/prompt.py
+++ b/frontends/krita/krita_comfy/prompt.py
@@ -1,20 +1,14 @@
-from dataclasses import dataclass, field
-from enum import Enum, unique
-from typing import List, Dict, Tuple
 import itertools
 import json
 import re
 import copy
+from dataclasses import dataclass, field
+from enum import Enum, unique
+from typing import List, Dict, Tuple
 
-from krita import (
-    QImage,
-    QByteArray,
-    QSize,
-    QBuffer,
-    QIODevice
-)
+from PyQt5.QtCore import QByteArray, QSize, QBuffer, QIODevice
+from PyQt5.QtGui import QImage
 
-from .config import DEFAULTS
 from .defaults import (
     DEFAULT_NODE_IDS
     , PROMPT

--- a/frontends/krita/krita_comfy/script.py
+++ b/frontends/krita/krita_comfy/script.py
@@ -3,18 +3,14 @@ import os
 import time
 import json
 
+from PyQt5.QtCore import QObject, QRect, QTimer, Qt, pyqtSignal
+from PyQt5.QtGui import QImage, QPixmap
+
 from krita import (
     Document,
     Krita,
     Node,
-    QImage,
-    QObject,
-    QPixmap,
-    QRect,
-    Qt,
-    QTimer,
     Selection,
-    pyqtSignal
 )
 
 from .prompt import PromptResponse, PromptBase, Base64Image

--- a/frontends/krita/krita_comfy/utils.py
+++ b/frontends/krita/krita_comfy/utils.py
@@ -3,15 +3,11 @@ import re
 from itertools import cycle
 from math import ceil
 
-from krita import (
-    Krita, 
-    QBuffer, 
-    QByteArray, 
-    QImage, 
-    QIODevice, 
-    Qt,
-    QLayout
-)
+from PyQt5.QtCore import QBuffer, QByteArray, QIODevice, Qt
+from PyQt5.QtGui import QImage
+from PyQt5.QtWidgets import QLayout
+
+from krita import Krita
 
 from .config import Config
 from .defaults import (
@@ -25,6 +21,7 @@ from .defaults import (
     TAB_CONTROLNET,
     TAB_WORKFLOW,
 )
+
 
 def fix_prompt(prompt: str):
     """Replace empty prompts with None."""
@@ -59,6 +56,7 @@ def get_ext_args(ext_cfg: Config, ext_type: str, ext_name: str):
         args.append(val)
     return args
 
+
 def calculate_resized_image_dimensions(
         base_size: int, max_size: int, orig_width: int, orig_height: int
 ):
@@ -83,7 +81,8 @@ def calculate_resized_image_dimensions(
             width, height = rnd(ratio, max_size), max_size
     
     return width, height
-        
+
+
 def find_fixed_aspect_ratio(
     base_size: int, max_size: int, orig_width: int, orig_height: int
 ):
@@ -94,6 +93,7 @@ def find_fixed_aspect_ratio(
     width, height = calculate_resized_image_dimensions(base_size, max_size, orig_width, orig_height)
     
     return width/height
+
 
 def find_optimal_selection_region(
     base_size: int,
@@ -224,6 +224,7 @@ def get_workflow(ext_cfg: Config, get_workflow_func, mode: str):
             d.page_widget.cfg_init()
             d.raise_()
             break
+
 
 def reset_docker_layout():
     """NOTE: Default stacking of dockers hardcoded here."""

--- a/frontends/krita/krita_comfy/widgets/checkbox.py
+++ b/frontends/krita/krita_comfy/widgets/checkbox.py
@@ -1,7 +1,7 @@
 from functools import partial
 
-from krita import QCheckBox as _QCheckBox
-from krita import QHBoxLayout, QVBoxLayout
+from PyQt5.QtWidgets import QCheckBox as _QCheckBox
+from PyQt5.QtWidgets import QHBoxLayout, QVBoxLayout
 
 from ..config import Config
 from .misc import QLabel

--- a/frontends/krita/krita_comfy/widgets/combo_box.py
+++ b/frontends/krita/krita_comfy/widgets/combo_box.py
@@ -1,7 +1,9 @@
 from functools import partial
 from typing import Union
 
-from krita import QComboBox, QHBoxLayout, Qt, QValidator
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QValidator
+from PyQt5.QtWidgets import QComboBox, QHBoxLayout
 
 from ..config import Config
 from .misc import QLabel

--- a/frontends/krita/krita_comfy/widgets/image_loader.py
+++ b/frontends/krita/krita_comfy/widgets/image_loader.py
@@ -1,4 +1,6 @@
-from krita import QApplication, QFileDialog, QPixmap, QPushButton, QVBoxLayout, QHBoxLayout, Qt
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPixmap
+from PyQt5.QtWidgets import QApplication, QFileDialog, QPushButton, QVBoxLayout, QHBoxLayout
 from ..widgets import QLabel
 
 class ImageLoaderLayout(QVBoxLayout):

--- a/frontends/krita/krita_comfy/widgets/line_edit.py
+++ b/frontends/krita/krita_comfy/widgets/line_edit.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from krita import QHBoxLayout, QLineEdit
+from PyQt5.QtWidgets import QHBoxLayout, QLineEdit
 
 from ..config import Config
 from .misc import QLabel

--- a/frontends/krita/krita_comfy/widgets/misc.py
+++ b/frontends/krita/krita_comfy/widgets/misc.py
@@ -1,5 +1,5 @@
-from krita import QLabel as _QLabel
-from krita import Qt
+from PyQt5.QtWidgets import QLabel as _QLabel
+from PyQt5.QtCore import Qt
 
 
 class QLabel(_QLabel):

--- a/frontends/krita/krita_comfy/widgets/prompt.py
+++ b/frontends/krita/krita_comfy/widgets/prompt.py
@@ -1,5 +1,4 @@
-from krita import QPlainTextEdit, QSizePolicy, QVBoxLayout
-
+from PyQt5.QtWidgets import QPlainTextEdit, QSizePolicy, QVBoxLayout
 from ..config import Config
 
 

--- a/frontends/krita/krita_comfy/widgets/spin_box.py
+++ b/frontends/krita/krita_comfy/widgets/spin_box.py
@@ -2,7 +2,7 @@ from functools import partial
 from math import isclose
 from typing import Union
 
-from krita import QDoubleSpinBox, QHBoxLayout, QSpinBox
+from PyQt5.QtWidgets import QDoubleSpinBox, QHBoxLayout, QSpinBox
 
 from ..config import Config
 from .misc import QLabel

--- a/frontends/krita/krita_comfy/widgets/tips.py
+++ b/frontends/krita/krita_comfy/widgets/tips.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from krita import QVBoxLayout
+from PyQt5.QtWidgets import QVBoxLayout
 
 from .misc import QLabel
 


### PR DESCRIPTION
@JasonS09 can you tell me if this breaks in your environment?

All the Qt objects should be imported directly from the QT package not from krita according to
https://docs.krita.org/en/user_manual/python_scripting/krita_python_plugin_howto.html

This means we can run most of the code outside of the krita runtime and stub the krita namespace with
https://github.com/rbreu/krita-python-mock
So we can make more comprehensive tests.

consistent import order
libs
pyqt/krita
internal