### PR TITLE
Feature Add: Lora/Embed Auto complete

### DIFF
--- a/frontends/krita/gui_test.py
+++ b/frontends/krita/gui_test.py
@@ -1,0 +1,29 @@
+import sys
+
+from PyQt5.QtWidgets import QMainWindow, QApplication, QVBoxLayout, QWidget
+
+from krita_comfy.config import Config
+from krita_comfy.pages.txt2img import Txt2ImgPage
+
+"""Test App for GUI components
+    This file is not part of the Krita plugin.
+    this is a way to invoke the plugin pages
+    outside of Krita to test and debug them directly.
+ """
+
+class Test_Window(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.cfg = Config()
+        self.setCentralWidget(QWidget())
+        layout = QVBoxLayout(self.centralWidget())
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.page = Txt2ImgPage()
+        layout.addWidget(self.page)
+
+
+if __name__ == "__main__":
+    app = QApplication(sys.argv)
+    window = Test_Window()
+    window.show()
+    sys.exit(app.exec_())

--- a/frontends/krita/krita_comfy/client.py
+++ b/frontends/krita/krita_comfy/client.py
@@ -38,7 +38,7 @@ from .utils import (
     calculate_resized_image_dimensions,
     re_lora,
     re_embedding,
-    auto_complete_LoRA
+    fuzzy_match_LoRA
 )
 
 from .prompt import PromptResponse
@@ -407,7 +407,7 @@ class Client(QObject):
             # Loop through the matches and create a node for each element
             for match in matches:
                 # Extract the lora name and the strength number from the match
-                lora_valid, lora_names = auto_complete_LoRA(self.cfg, match[0])
+                lora_valid, lora_names = fuzzy_match_LoRA(self.cfg, match[0])
                 lora_name = lora_names[0] if lora_valid else match[0]
                 strength_number = float(match[1])
 

--- a/frontends/krita/krita_comfy/pages/img_base.py
+++ b/frontends/krita/krita_comfy/pages/img_base.py
@@ -27,10 +27,6 @@ class SDImgPageBase(QWidget):
             script.cfg, f"{cfg_prefix}_prompt", f"{cfg_prefix}_negative_prompt"
         )
 
-        # Connect Highlighter
-        self.highlighter = QPromptHighLighter(script.cfg, self.prompt_layout.qedit_prompt.document())
-        self.neg_highlighter = QPromptHighLighter(script.cfg, self.prompt_layout.qedit_neg_prompt.document())
-
         self.prompt_layer_load = QPushButton("Load Prompt from Layer")
 
         self.seed_layout = QLineEditLayout(

--- a/frontends/krita/krita_comfy/utils.py
+++ b/frontends/krita/krita_comfy/utils.py
@@ -228,25 +228,32 @@ def get_workflow(ext_cfg: Config, get_workflow_func, mode: str):
             break
 
 
-def auto_complete_LoRA(cfg: Config, name: str) -> (bool, [str]):
+def fuzzy_match_LoRA(cfg: Config, name: str) -> (bool, [str]):
+    # Take the given string and attempt to match it to the sd_lora_list
+    # Return true if we should use the return string instead
     lora_list = [re.sub(".safetensors$", "", lora, flags=re.I) for lora in cfg("sd_lora_list", str)]
     viable_loras = [lora for lora in lora_list if re.search(re.escape(name)+"$", lora, flags=re.I)]
     valid = len(viable_loras) == 1
     return valid, viable_loras
 
 
-def auto_complete_embedding(cfg: Config, name: str) -> (bool, [str]):
+def fuzzy_match_embedding(cfg: Config, name: str) -> (bool, [str]):
+    # Take the given string and attempt to match it to the sd_embedding_list
+    # Return true if we should use the return string instead
     embed_list: List[str] = cfg("sd_embedding_list", str)
     viable_embed = [embed for embed in embed_list if re.search('^'+re.escape(name)+'$', embed)]
     valid = len(viable_embed) == 1
     return valid, viable_embed
 
 
-def get_simple_lora_list(cfg: Config) -> List[str]:
+def get_autocomplete_lora_list(cfg: Config) -> List[str]:
+    # Return a list of lora names
+    # unless there are lora with the same name under diffrent paths
+    # TODO look into QCompleter::splitPath
     lora_list: Dict[str, List[PurePath]] = {}
     for lora in [PurePath(lora) for lora in cfg("sd_lora_list", str)]:
         if lora_list.get(lora.stem) is not None:
-            lora_list[lora.stem].append(lora)
+            lora_list[lora.stem].append(lora.with_suffix(''))  # Remove .safetensors
         else:
             lora_list[lora.stem] = [lora]
 

--- a/frontends/krita/krita_comfy/utils.py
+++ b/frontends/krita/krita_comfy/utils.py
@@ -26,7 +26,7 @@ from .defaults import (
 
 
 re_lora = r"<lora:([=\[\] \\/\w\d.-]+):(\-?[\d.]+)>"
-re_lora_start = r"<lora:([=\[\] \\/\w\d.-]+)"
+re_lora_start = r"<lora:([=\[\]\\/\w\d.-]+)"
 re_embedding = r"embedding\:([^ \n$]+)"
 
 

--- a/frontends/krita/krita_comfy/widgets/prompt.py
+++ b/frontends/krita/krita_comfy/widgets/prompt.py
@@ -32,7 +32,7 @@ class QPromptEdit(QPlainTextEdit):
         tc.movePosition(QTextCursor.EndOfWord)
         tc.insertText(text[-extra:])
         self.setTextCursor(tc)
-        self.completer.popup().hide()
+        self.completer.hide_popup()
 
     def focusInEvent(self, e: QFocusEvent) -> None:
         if self.completer:
@@ -44,14 +44,17 @@ class QPromptEdit(QPlainTextEdit):
             QPlainTextEdit.keyPressEvent(self, e)
             return
 
-        if e.key() == Qt.Key_Tab and self.completer.popup().isVisible():
-            self.completer.insertText.emit(self.completer.getSelected())
-            return
+        if self.completer.is_popup_visible():
+            key = e.key()
+            if key == Qt.Key_Enter or key == Qt.Key_Return:
+                self.completer.insertText.emit(self.completer.getSelected())
+                return
 
         QPlainTextEdit.keyPressEvent(self, e)
         tc: QTextCursor = self.textCursor()
-        tc.select(QTextCursor.WordUnderCursor)
         cr: QRect = self.cursorRect()
+        tc.select(QTextCursor.LineUnderCursor)
+        self.completer.setWidget(self)
         self.completer.try_auto_complete(tc, cr)
 
 

--- a/frontends/krita/krita_comfy/widgets/prompt.py
+++ b/frontends/krita/krita_comfy/widgets/prompt.py
@@ -26,11 +26,11 @@ class QPromptEdit(QPlainTextEdit):
         self.completer.insertText.connect(self.insertCompletion)
 
     def insertCompletion(self, text):
-        tc = self.textCursor()
-        extra = (len(text) - len(self.completer.completionPrefix()))
-        tc.movePosition(QTextCursor.Left)
-        tc.movePosition(QTextCursor.EndOfWord)
-        tc.insertText(text[-extra:])
+        tc: QTextCursor = self.textCursor()
+        prefix_len: int = len(self.completer.completionPrefix())
+        tc.movePosition(QTextCursor.Left, mode=QTextCursor.KeepAnchor, n=prefix_len)
+        tc.removeSelectedText()
+        tc.insertText(text)
         self.setTextCursor(tc)
         self.completer.hide_popup()
 
@@ -53,7 +53,6 @@ class QPromptEdit(QPlainTextEdit):
         QPlainTextEdit.keyPressEvent(self, e)
         tc: QTextCursor = self.textCursor()
         cr: QRect = self.cursorRect()
-        tc.select(QTextCursor.LineUnderCursor)
         self.completer.setWidget(self)
         self.completer.try_auto_complete(tc, cr)
 

--- a/frontends/krita/krita_comfy/widgets/prompt_complete.py
+++ b/frontends/krita/krita_comfy/widgets/prompt_complete.py
@@ -1,5 +1,6 @@
 import re
-from typing import List, Tuple
+from typing import List, Tuple, Optional
+from dataclasses import dataclass, field
 
 from PyQt5.QtCore import Qt, pyqtSignal, QStringListModel, QRect
 from PyQt5.QtGui import QSyntaxHighlighter, QColor, QTextCursor
@@ -7,13 +8,51 @@ from PyQt5.QtWidgets import QCompleter
 
 from ..config import Config
 from ..utils import (
-    auto_complete_LoRA,
-    auto_complete_embedding,
-    get_simple_lora_list,
+    fuzzy_match_LoRA,
+    fuzzy_match_embedding,
+    get_autocomplete_lora_list,
     re_embedding,
     re_lora,
     re_lora_start,
 )
+
+
+@dataclass
+class SDCompleter:
+    matcher: re.Pattern
+    cfg: Config
+    autocomplete_suffix: str
+    autocomplete_list: List[str] = field(default_factory=str)
+
+    def update(self):
+        return
+
+
+class LoraCompleter(SDCompleter):
+    def __init__(self, cfg: Config):
+        super().__init__(
+            re.compile(re_lora_start + '$'),
+            cfg,
+            ":0.5>"
+        )
+        self.update()
+
+    def update(self):
+        self.autocomplete_list = get_autocomplete_lora_list(self.cfg)
+
+
+class EmbeddingCompleter(SDCompleter):
+    def __init__(self, cfg: Config):
+        super().__init__(
+            re.compile(re_embedding + '$'),
+            cfg,
+            " ",
+
+        )
+        self.update()
+
+    def update(self):
+        self.autocomplete_list = self.cfg("sd_embedding_list", str)
 
 
 class QPromptHighLighter(QSyntaxHighlighter):
@@ -22,17 +61,13 @@ class QPromptHighLighter(QSyntaxHighlighter):
 
         self.cfg = cfg
         self.highlighters = [
-            [re_lora, auto_complete_LoRA],
-            [re_embedding, auto_complete_embedding]]
+            [re_lora, fuzzy_match_LoRA],
+            [re_embedding, fuzzy_match_embedding]]
 
     def highlightBlock(self, line):
         for expression, func in self.highlighters:
             for m in re.finditer(expression, line):
                 valid, names = func(self.cfg, m.group(1))
-                color: QColor = QColor(Qt.green)
-                color = color if valid else QColor(Qt.red)
-                color = color if len(names) < 2 else QColor(Qt.yellow)
-                self.setFormat(m.start(0), m.end(0)-m.start(0), color)
                 color: QColor = QColor(Qt.green)
                 color = color if valid else QColor(Qt.red)
                 color = color if len(names) < 2 else QColor(Qt.yellow)
@@ -53,34 +88,40 @@ class QPromptCompleter(QCompleter):
         self.highlighted.connect(self.setHighlighted)
         self.setMaxVisibleItems(5)
         self.cfg = cfg
-        self.rules: List[Tuple[str, List[str]]] = [
-            (re_embedding, self.cfg("sd_embedding_list", str)),
-            (re_lora_start, get_simple_lora_list(self.cfg))
-        ]
+        self.rules: List[SDCompleter] = [
+            LoraCompleter(cfg),
+            EmbeddingCompleter(cfg)]
+        self.rule: Optional[SDCompleter] = None
+
+    def hide_popup(self):
+        self.rule = None
+        self.popup().hide()
+
+    def is_popup_visible(self):
+        return self.popup().isVisible()
 
     def set_string_list(self, keys: List[str]):
+        self.setCompletionMode(QCompleter.PopupCompletion)
         self.model.setStringList(keys)
 
     def setHighlighted(self, text):
         self.lastSelected = text
 
     def getSelected(self):
-        return self.lastSelected
+        extra = "" if self.rule is None else self.rule.autocomplete_suffix
+        return self.lastSelected + extra
 
     def try_auto_complete(self, tc: QTextCursor, cr: QRect):
         # Get the line
         tc.select(QTextCursor.LineUnderCursor)
         line = tc.selectedText()
 
-        # Match re and completion lists
-        rule: Tuple[str, List[str]] = None
-        match: re.Match[str] = None
-
+        match: Optional[re.Match] = None
         # match last occurrence of rule on the line
         for r in self.rules:
-            match = re.search(r[0] + "$", line)
+            match = re.search(r.matcher, line)
             if match is not None:
-                rule = r
+                self.rule = r
                 break
 
         if match is not None:
@@ -89,7 +130,8 @@ class QPromptCompleter(QCompleter):
             tc.movePosition(QTextCursor.Right, mode=QTextCursor.MoveAnchor, n=match.span(1)[0])
             tc.movePosition(QTextCursor.Right, mode=QTextCursor.KeepAnchor, n=match.span(1)[1])
             # update the completer for with the list for this rule
-            self.set_string_list(rule[1])
+            self.rule.update()
+            self.set_string_list(self.rule.autocomplete_list)
             self.setCompletionPrefix(tc.selectedText())
             popup = self.popup()
             popup.setCurrentIndex(self.completionModel().index(0, 0))
@@ -97,4 +139,4 @@ class QPromptCompleter(QCompleter):
                         + popup.verticalScrollBar().sizeHint().width())
             self.complete(cr)
         else:
-            self.popup().hide()
+            self.hide_popup()

--- a/frontends/krita/krita_comfy/widgets/prompt_complete.py
+++ b/frontends/krita/krita_comfy/widgets/prompt_complete.py
@@ -1,0 +1,98 @@
+import re
+from typing import List, Tuple
+
+from PyQt5.QtCore import Qt, pyqtSignal, QStringListModel, QRect
+from PyQt5.QtGui import QSyntaxHighlighter, QColor, QTextCursor
+from PyQt5.QtWidgets import QCompleter
+
+from ..config import Config
+from ..utils import (
+    auto_complete_LoRA,
+    auto_complete_embedding,
+    get_simple_lora_list,
+    re_embedding,
+    re_lora,
+    re_lora_start,
+)
+
+
+class QPromptHighLighter(QSyntaxHighlighter):
+    def __init__(self, cfg: Config, *args, **kwargs):
+        super(QSyntaxHighlighter, self).__init__(*args, **kwargs)
+
+        self.cfg = cfg
+        self.highlighters = [
+            [re_lora, auto_complete_LoRA],
+            [re_embedding, auto_complete_embedding]]
+
+    def highlightBlock(self, line):
+        for expression, func in self.highlighters:
+            for m in re.finditer(expression, line):
+                valid, names = func(self.cfg, m.group(1))
+                color: QColor = QColor(Qt.green)
+                color = color if valid else QColor(Qt.red)
+                color = color if len(names) < 2 else QColor(Qt.yellow)
+                self.setFormat(m.start(0), m.end(0)-m.start(0), color)
+                color: QColor = QColor(Qt.green)
+                color = color if valid else QColor(Qt.red)
+                color = color if len(names) < 2 else QColor(Qt.yellow)
+                self.setFormat(m.start(0), m.end(0)-m.start(0), color)
+
+
+class QPromptCompleter(QCompleter):
+    insertText = pyqtSignal(str)
+    lastSelected: str = None
+    model: QStringListModel = None
+
+    def __init__(self, cfg: Config, parent=None):
+        super().__init__(parent)
+        self.model = QStringListModel()
+        self.setModel(self.model)
+        self.setCompletionMode(QCompleter.PopupCompletion)
+        self.setCaseSensitivity(Qt.CaseInsensitive)
+        self.highlighted.connect(self.setHighlighted)
+        self.setMaxVisibleItems(5)
+        self.cfg = cfg
+
+    def set_string_list(self, keys: List[str]):  # "sd_embedding_list"
+        self.model.setStringList(keys)
+
+    def setHighlighted(self, text):
+        self.lastSelected = text
+
+    def getSelected(self):
+        return self.lastSelected
+
+    def try_auto_complete(self, tc: QTextCursor, cr: QRect):
+        # Get the line
+        tc.select(QTextCursor.LineUnderCursor)
+        line = tc.selectedText()
+        # Select current word so we can replace it
+        tc.select(QTextCursor.WordUnderCursor)
+        # Match list and completion lists
+        rules: List[Tuple[str, List[str]]] = [
+            (re_embedding, self.cfg("sd_embedding_list", str)),
+            (re_lora_start, get_simple_lora_list(self.cfg))
+        ]
+        rule: Tuple[str, List[str]] = None
+        match = None
+
+        # match last occurrence of rule on the line
+        for r in rules:
+            match = re.findall(r[0] + "$", line)
+            if len(match) > 0:
+                rule = r
+                break
+
+        if match is not None and len(match) > 0:
+            # update the completer for with the list for this rule
+            print(rule[1])
+            self.set_string_list(rule[1])
+            self.setCompletionPrefix(tc.selectedText())
+            popup = self.popup()
+            popup.setCurrentIndex(self.completionModel().index(0, 0))
+            cr.setWidth(popup.sizeHintForColumn(0)
+                        + popup.verticalScrollBar().sizeHint().width())
+            self.complete(cr)
+        else:
+            self.popup().hide()


### PR DESCRIPTION
- Lora/Embedding now suggest completions to the user.
- After typing `embedding:` or `<lora:`
- Use enter/return to use the auto complete

Looking for feedback on:
- Do we need a way to disable this?
- Any other patterns?
- Should we use an explicit shortcut to invoke (eg ctrl-e)