### PR TITLE
Remove unused options

### DIFF
--- a/frontends/krita/krita_comfy/client.py
+++ b/frontends/krita/krita_comfy/client.py
@@ -34,7 +34,6 @@ from .defaults import (
     THREADED,
 )
 from .utils import (
-    bytewise_xor,
     img_to_b64,
     calculate_resized_image_dimensions
 )
@@ -73,7 +72,6 @@ class AsyncRequest(QObject):
         timeout: int = ...,
         method: str = ...,
         headers: dict = ...,
-        key: str = None,
     ):
         """Create an AsyncRequest object.
 
@@ -86,7 +84,6 @@ class AsyncRequest(QObject):
             data (Any, optional): Payload to send. Defaults to None.
             timeout (int, optional): Timeout for request. Defaults to `...`.
             method (str, optional): Which HTTP method to use. Defaults to `...`.
-            key (Union[str, None], Optional): Key to use for encryption/decryption. Defaults to None.
             headers (dict, optional): dictionary of headers to send to request.
             is_upload: if set to true, request will be sent as multipart/form-data type.
         """
@@ -95,12 +92,6 @@ class AsyncRequest(QObject):
         self.data = data
         self.headers = {} if headers is ... else headers
 
-        self.key = None
-        if isinstance(key, str) and key.strip() != "":
-            self.key = key.strip().encode("utf-8")
-
-        if self.key is not None:
-            self.headers["X-Encrypted-Body"] = "XOR"
         if timeout is not ...:
             self.timeout = timeout
         if method is ...:
@@ -111,12 +102,6 @@ class AsyncRequest(QObject):
             self.data = None if data is None else json.dumps(
                 data).encode("utf-8")
 
-            if self.data is not None and self.key is not None:
-                # print(f"Encrypting with ${self.key}:\n{self.data}")
-                self.data = bytewise_xor(self.data, self.key)
-                # print(f"Encrypt Result:\n{self.data}")
-                self.headers["Content-Type"] = "application/json"
-                self.headers["Content-Length"] = str(len(self.data))
         self.headers["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 Edg/115.0.1901.200"
         #self.headers["accept"] = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
     def run(self):
@@ -130,12 +115,6 @@ class AsyncRequest(QObject):
             req = Request(url, headers=self.headers, method=self.method)
             with urlopen(req, self.data if self.method == "POST" else None, self.timeout, context=ctx) as res:
                 data = res.read()
-                enc_type = res.getheader("X-Encrypted-Body", None)
-                assert enc_type in {"XOR", None}, "Unknown server encryption!"
-                if enc_type == "XOR":
-                    assert self.key, "Key needed to decrypt server response!"
-                    print(f"Decrypting with ${self.key}:\n{data}")
-                    data = bytewise_xor(data, self.key)
                 self.result.emit(json.loads(data))
         except ValueError as e:
             self.result.emit(data)
@@ -292,7 +271,6 @@ class Client(QObject):
             url,
             body,
             LONG_TIMEOUT if is_long else SHORT_TIMEOUT,
-            key=self.cfg("encryption_key"),
             method=method,
             headers=headers
         )

--- a/frontends/krita/krita_comfy/defaults.py
+++ b/frontends/krita/krita_comfy/defaults.py
@@ -114,7 +114,6 @@ class Defaults:
     save_temp_images: bool = False
     fix_aspect_ratio: bool = True
     only_full_img_tiling: bool = True
-    filter_nsfw: bool = False
     do_exact_steps: bool = True
     sample_path: str = "./tmp"
     minimize_ui: bool = False

--- a/frontends/krita/krita_comfy/defaults.py
+++ b/frontends/krita/krita_comfy/defaults.py
@@ -163,7 +163,6 @@ class Defaults:
     img2img_cfg_scale: float = 8.0
     img2img_denoising_strength: float = 0.5
     img2img_seed: str = ""
-    img2img_color_correct: bool = False
     img2img_input_save_as: str = "input.png"
     img2img_workflow: str = ""
     img2img_custom_workflow: bool = False
@@ -187,7 +186,6 @@ class Defaults:
     inpaint_fill: str = "preserve"
     # inpaint_full_res: bool = False
     # inpaint_full_res_padding: int = 32
-    inpaint_color_correct: bool = False
     inpaint_mask_weight: float = 1.0
     inpaint_workflow: str = ""
     inpaint_custom_workflow: bool = False

--- a/frontends/krita/krita_comfy/defaults.py
+++ b/frontends/krita/krita_comfy/defaults.py
@@ -112,7 +112,6 @@ class Defaults:
     create_mask_layer: bool = True
     save_temp_images: bool = False
     fix_aspect_ratio: bool = True
-    do_exact_steps: bool = True
     sample_path: str = "./tmp"
     minimize_ui: bool = False
     first_setup: bool = True  # only used for the initial docker layout

--- a/frontends/krita/krita_comfy/defaults.py
+++ b/frontends/krita/krita_comfy/defaults.py
@@ -118,7 +118,6 @@ class Defaults:
     first_setup: bool = True  # only used for the initial docker layout
     alt_dock_behavior: bool = False
     hide_layers: bool = True
-    no_groups: bool = False
     disable_sddebz_highres: bool = False
 
     sd_model_list: List[str] = field(default_factory=lambda: [ERROR_MSG])

--- a/frontends/krita/krita_comfy/defaults.py
+++ b/frontends/krita/krita_comfy/defaults.py
@@ -112,7 +112,6 @@ class Defaults:
     create_mask_layer: bool = True
     save_temp_images: bool = False
     fix_aspect_ratio: bool = True
-    only_full_img_tiling: bool = True
     do_exact_steps: bool = True
     sample_path: str = "./tmp"
     minimize_ui: bool = False

--- a/frontends/krita/krita_comfy/defaults.py
+++ b/frontends/krita/krita_comfy/defaults.py
@@ -109,7 +109,6 @@ NEGATIVE_PROMPT = "<<NegativePrompt>>"
 @dataclass(frozen=True)
 class Defaults:
     base_url: str = "http://127.0.0.1:8188"
-    encryption_key: str = ""
     just_use_yaml: bool = False
     create_mask_layer: bool = True
     save_temp_images: bool = False

--- a/frontends/krita/krita_comfy/defaults.py
+++ b/frontends/krita/krita_comfy/defaults.py
@@ -139,7 +139,6 @@ class Defaults:
     face_restorer_model_list: List[str] = field(default_factory=lambda: [ERROR_MSG])
     face_restorer_model: str = "None"
     codeformer_weight: float = 0.5
-    include_grid: bool = False
 
     txt2img_prompt: str = ""
     txt2img_negative_prompt: str = ""

--- a/frontends/krita/krita_comfy/defaults.py
+++ b/frontends/krita/krita_comfy/defaults.py
@@ -109,7 +109,6 @@ NEGATIVE_PROMPT = "<<NegativePrompt>>"
 @dataclass(frozen=True)
 class Defaults:
     base_url: str = "http://127.0.0.1:8188"
-    just_use_yaml: bool = False
     create_mask_layer: bool = True
     save_temp_images: bool = False
     fix_aspect_ratio: bool = True

--- a/frontends/krita/krita_comfy/pages/config.py
+++ b/frontends/krita/krita_comfy/pages/config.py
@@ -32,9 +32,6 @@ class ConfigPage(QWidget):
         self.fix_aspect_ratio = QCheckBox(
             script.cfg, "fix_aspect_ratio", "Adjust selection aspect ratio"
         )
-        self.include_grid = QCheckBox(
-            script.cfg, "include_grid", "Include txt2img/img2img grid"
-        )
         self.minimize_ui = QCheckBox(script.cfg, "minimize_ui", "Squeeze the UI")
         self.alt_docker = QCheckBox(
             script.cfg, "alt_dock_behavior", "Alt Docker Behaviour"
@@ -76,7 +73,6 @@ class ConfigPage(QWidget):
         layout_inner.addWidget(self.create_mask_layer)
         layout_inner.addWidget(self.hide_layers)
         layout_inner.addWidget(self.no_groups)
-        layout_inner.addWidget(self.include_grid)
         layout_inner.addWidget(self.save_temp_images)
 
         layout_inner.addWidget(QLabel("<em>Backend/webUI settings:</em>"))
@@ -108,8 +104,6 @@ class ConfigPage(QWidget):
 
         self.create_mask_layer.cfg_init()
         self.save_temp_images.cfg_init()
-        self.fix_aspect_ratio.cfg_init()
-        self.include_grid.cfg_init()
         self.img2img_color_correct.cfg_init()
         self.inpaint_color_correct.cfg_init()
         self.do_exact_steps.cfg_init()
@@ -144,7 +138,6 @@ class ConfigPage(QWidget):
         self.create_mask_layer.cfg_connect()
         self.save_temp_images.cfg_connect()
         self.fix_aspect_ratio.cfg_connect()
-        self.include_grid.cfg_connect()
         self.img2img_color_correct.cfg_connect()
         self.inpaint_color_correct.cfg_connect()
         self.do_exact_steps.cfg_connect()

--- a/frontends/krita/krita_comfy/pages/config.py
+++ b/frontends/krita/krita_comfy/pages/config.py
@@ -23,9 +23,6 @@ class ConfigPage(QWidget):
         inline1.addWidget(self.base_url_reset)
 
         # Plugin settings
-        self.just_use_yaml = QCheckBox(
-            script.cfg, "just_use_yaml", "(unrecommended) Ignore settings"
-        )
         self.create_mask_layer = QCheckBox(
             script.cfg, "create_mask_layer", "Add transparency mask"
         )
@@ -85,7 +82,6 @@ class ConfigPage(QWidget):
         layout_inner.addWidget(self.only_full_img_tiling)
         layout_inner.addWidget(self.include_grid)
         layout_inner.addWidget(self.save_temp_images)
-        # layout_inner.addWidget(self.just_use_yaml)
 
         layout_inner.addWidget(QLabel("<em>Backend/webUI settings:</em>"))
         layout_inner.addWidget(self.img2img_color_correct)
@@ -114,7 +110,6 @@ class ConfigPage(QWidget):
         if self.base_url.text() != base_url:
             self.base_url.setText(base_url)
 
-        self.just_use_yaml.cfg_init()
         self.create_mask_layer.cfg_init()
         self.save_temp_images.cfg_init()
         self.fix_aspect_ratio.cfg_init()
@@ -151,7 +146,6 @@ class ConfigPage(QWidget):
         self.base_url_reset.released.connect(
             lambda: self.base_url.setText(DEFAULTS.base_url)
         )
-        self.just_use_yaml.cfg_connect()
         self.create_mask_layer.cfg_connect()
         self.save_temp_images.cfg_connect()
         self.fix_aspect_ratio.cfg_connect()

--- a/frontends/krita/krita_comfy/pages/config.py
+++ b/frontends/krita/krita_comfy/pages/config.py
@@ -37,7 +37,6 @@ class ConfigPage(QWidget):
             script.cfg, "alt_dock_behavior", "Alt Docker Behaviour"
         )
         self.hide_layers = QCheckBox(script.cfg, "hide_layers", "Auto hide layers")
-        self.no_groups = QCheckBox(script.cfg, "no_groups", "Don't create group layers")
 
         # webUI/backend settings
         self.do_exact_steps = QCheckBox(
@@ -66,7 +65,6 @@ class ConfigPage(QWidget):
         layout_inner.addWidget(self.fix_aspect_ratio)
         layout_inner.addWidget(self.create_mask_layer)
         layout_inner.addWidget(self.hide_layers)
-        layout_inner.addWidget(self.no_groups)
         layout_inner.addWidget(self.save_temp_images)
 
         layout_inner.addWidget(QLabel("<em>Backend/webUI settings:</em>"))
@@ -100,7 +98,6 @@ class ConfigPage(QWidget):
         self.minimize_ui.cfg_init()
         self.alt_docker.cfg_init()
         self.hide_layers.cfg_init()
-        self.no_groups.cfg_init()
 
         info_text = """
             <em>Tip:</em> Only a selected few backend/webUI settings are exposed above.<br/>
@@ -132,7 +129,6 @@ class ConfigPage(QWidget):
         self.minimize_ui.cfg_connect()
         self.alt_docker.cfg_connect()
         self.hide_layers.cfg_connect()
-        self.no_groups.cfg_connect()
 
         def restore_defaults():
             script.restore_defaults()

--- a/frontends/krita/krita_comfy/pages/config.py
+++ b/frontends/krita/krita_comfy/pages/config.py
@@ -49,7 +49,6 @@ class ConfigPage(QWidget):
         self.no_groups = QCheckBox(script.cfg, "no_groups", "Don't create group layers")
 
         # webUI/backend settings
-        self.filter_nsfw = QCheckBox(script.cfg, "filter_nsfw", "Filter NSFW")
         self.img2img_color_correct = QCheckBox(
             script.cfg, "img2img_color_correct", "Color correct img2img"
         )
@@ -89,7 +88,6 @@ class ConfigPage(QWidget):
         # layout_inner.addWidget(self.just_use_yaml)
 
         layout_inner.addWidget(QLabel("<em>Backend/webUI settings:</em>"))
-        layout_inner.addWidget(self.filter_nsfw)
         layout_inner.addWidget(self.img2img_color_correct)
         layout_inner.addWidget(self.inpaint_color_correct)
         layout_inner.addWidget(self.do_exact_steps)
@@ -122,7 +120,6 @@ class ConfigPage(QWidget):
         self.fix_aspect_ratio.cfg_init()
         self.only_full_img_tiling.cfg_init()
         self.include_grid.cfg_init()
-        self.filter_nsfw.cfg_init()
         self.img2img_color_correct.cfg_init()
         self.inpaint_color_correct.cfg_init()
         self.do_exact_steps.cfg_init()
@@ -160,7 +157,6 @@ class ConfigPage(QWidget):
         self.fix_aspect_ratio.cfg_connect()
         self.only_full_img_tiling.cfg_connect()
         self.include_grid.cfg_connect()
-        self.filter_nsfw.cfg_connect()
         self.img2img_color_correct.cfg_connect()
         self.inpaint_color_correct.cfg_connect()
         self.do_exact_steps.cfg_connect()

--- a/frontends/krita/krita_comfy/pages/config.py
+++ b/frontends/krita/krita_comfy/pages/config.py
@@ -38,13 +38,6 @@ class ConfigPage(QWidget):
         )
         self.hide_layers = QCheckBox(script.cfg, "hide_layers", "Auto hide layers")
 
-        # webUI/backend settings
-        self.do_exact_steps = QCheckBox(
-            script.cfg,
-            "do_exact_steps",
-            "Exact number of steps for denoising",
-        )
-
         self.refresh_btn = QPushButton("Auto-Refresh Options Now")
         self.restore_defaults = QPushButton("Restore Defaults")
 
@@ -68,7 +61,6 @@ class ConfigPage(QWidget):
         layout_inner.addWidget(self.save_temp_images)
 
         layout_inner.addWidget(QLabel("<em>Backend/webUI settings:</em>"))
-        layout_inner.addWidget(self.do_exact_steps)
 
         # TODO: figure out how to set height of scroll area when there are too many options
         # or maybe an option search bar
@@ -94,7 +86,6 @@ class ConfigPage(QWidget):
 
         self.create_mask_layer.cfg_init()
         self.save_temp_images.cfg_init()
-        self.do_exact_steps.cfg_init()
         self.minimize_ui.cfg_init()
         self.alt_docker.cfg_init()
         self.hide_layers.cfg_init()
@@ -125,7 +116,6 @@ class ConfigPage(QWidget):
         self.create_mask_layer.cfg_connect()
         self.save_temp_images.cfg_connect()
         self.fix_aspect_ratio.cfg_connect()
-        self.do_exact_steps.cfg_connect()
         self.minimize_ui.cfg_connect()
         self.alt_docker.cfg_connect()
         self.hide_layers.cfg_connect()

--- a/frontends/krita/krita_comfy/pages/config.py
+++ b/frontends/krita/krita_comfy/pages/config.py
@@ -58,9 +58,6 @@ class ConfigPage(QWidget):
         layout_inner.addWidget(self.fix_aspect_ratio)
         layout_inner.addWidget(self.create_mask_layer)
         layout_inner.addWidget(self.hide_layers)
-        layout_inner.addWidget(self.save_temp_images)
-
-        layout_inner.addWidget(QLabel("<em>Backend/webUI settings:</em>"))
 
         # TODO: figure out how to set height of scroll area when there are too many options
         # or maybe an option search bar

--- a/frontends/krita/krita_comfy/pages/config.py
+++ b/frontends/krita/krita_comfy/pages/config.py
@@ -22,10 +22,6 @@ class ConfigPage(QWidget):
         inline1.addWidget(self.base_url)
         inline1.addWidget(self.base_url_reset)
 
-        self.enc_key = QLineEditLayout(
-            script.cfg, "encryption_key", "Optional Encryption Key"
-        )
-
         # Plugin settings
         self.just_use_yaml = QCheckBox(
             script.cfg, "just_use_yaml", "(unrecommended) Ignore settings"
@@ -106,7 +102,6 @@ class ConfigPage(QWidget):
         layout.addWidget(self.status_bar)
         layout.addWidget(QLabel("<em>Backend url:</em>"))
         layout.addLayout(inline1)
-        layout.addLayout(self.enc_key)
         layout.addLayout(layout_inner)
         layout.addWidget(self.refresh_btn)
         layout.addWidget(self.restore_defaults)
@@ -121,7 +116,6 @@ class ConfigPage(QWidget):
         if self.base_url.text() != base_url:
             self.base_url.setText(base_url)
 
-        self.enc_key.cfg_init()
         self.just_use_yaml.cfg_init()
         self.create_mask_layer.cfg_init()
         self.save_temp_images.cfg_init()
@@ -141,10 +135,14 @@ class ConfigPage(QWidget):
             <em>Tip:</em> Only a selected few backend/webUI settings are exposed above.<br/>
             <em>Tip:</em> You should look through & configure all the backend/webUI settings at least once.
             <br/><br/>
-            <a href="http://127.0.0.1:7860/" target="_blank">Configure all settings in webUI</a><br/>
-            <a href="https://github.com/Interpause/auto-sd-paint-ext/wiki" target="_blank">Read the guide</a><br/>
-            <a href="https://github.com/Interpause/auto-sd-paint-ext/issues" target="_blank">Report bugs or suggest features</a>
-            """
+            <a href="{}" target="_blank">Configure all settings in webUI</a><br/>
+            <a href="{}" target="_blank">Read the guide</a><br/>
+            <a href="{}" target="_blank">Report bugs or suggest features</a>
+            """.format(
+            script.cfg("base_url", str),
+            "https://github.com/JasonS09/comfy_sd_krita_plugin/wiki",
+            "https://github.com/JasonS09/comfy_sd_krita_plugin/issues",
+            )
         if script.cfg("minimize_ui", bool):
             info_text = "\n".join(info_text.split("\n")[-4:-1])
         self.info_label.setText(info_text)
@@ -156,7 +154,6 @@ class ConfigPage(QWidget):
         self.base_url_reset.released.connect(
             lambda: self.base_url.setText(DEFAULTS.base_url)
         )
-        self.enc_key.cfg_connect()
         self.just_use_yaml.cfg_connect()
         self.create_mask_layer.cfg_connect()
         self.save_temp_images.cfg_connect()

--- a/frontends/krita/krita_comfy/pages/config.py
+++ b/frontends/krita/krita_comfy/pages/config.py
@@ -32,9 +32,6 @@ class ConfigPage(QWidget):
         self.fix_aspect_ratio = QCheckBox(
             script.cfg, "fix_aspect_ratio", "Adjust selection aspect ratio"
         )
-        self.only_full_img_tiling = QCheckBox(
-            script.cfg, "only_full_img_tiling", "Disallow tiling with selection"
-        )
         self.include_grid = QCheckBox(
             script.cfg, "include_grid", "Include txt2img/img2img grid"
         )
@@ -79,7 +76,6 @@ class ConfigPage(QWidget):
         layout_inner.addWidget(self.create_mask_layer)
         layout_inner.addWidget(self.hide_layers)
         layout_inner.addWidget(self.no_groups)
-        layout_inner.addWidget(self.only_full_img_tiling)
         layout_inner.addWidget(self.include_grid)
         layout_inner.addWidget(self.save_temp_images)
 
@@ -113,7 +109,6 @@ class ConfigPage(QWidget):
         self.create_mask_layer.cfg_init()
         self.save_temp_images.cfg_init()
         self.fix_aspect_ratio.cfg_init()
-        self.only_full_img_tiling.cfg_init()
         self.include_grid.cfg_init()
         self.img2img_color_correct.cfg_init()
         self.inpaint_color_correct.cfg_init()
@@ -149,7 +144,6 @@ class ConfigPage(QWidget):
         self.create_mask_layer.cfg_connect()
         self.save_temp_images.cfg_connect()
         self.fix_aspect_ratio.cfg_connect()
-        self.only_full_img_tiling.cfg_connect()
         self.include_grid.cfg_connect()
         self.img2img_color_correct.cfg_connect()
         self.inpaint_color_correct.cfg_connect()

--- a/frontends/krita/krita_comfy/pages/config.py
+++ b/frontends/krita/krita_comfy/pages/config.py
@@ -40,12 +40,6 @@ class ConfigPage(QWidget):
         self.no_groups = QCheckBox(script.cfg, "no_groups", "Don't create group layers")
 
         # webUI/backend settings
-        self.img2img_color_correct = QCheckBox(
-            script.cfg, "img2img_color_correct", "Color correct img2img"
-        )
-        self.inpaint_color_correct = QCheckBox(
-            script.cfg, "inpaint_color_correct", "Color correct inpaint"
-        )
         self.do_exact_steps = QCheckBox(
             script.cfg,
             "do_exact_steps",
@@ -76,8 +70,6 @@ class ConfigPage(QWidget):
         layout_inner.addWidget(self.save_temp_images)
 
         layout_inner.addWidget(QLabel("<em>Backend/webUI settings:</em>"))
-        layout_inner.addWidget(self.img2img_color_correct)
-        layout_inner.addWidget(self.inpaint_color_correct)
         layout_inner.addWidget(self.do_exact_steps)
 
         # TODO: figure out how to set height of scroll area when there are too many options
@@ -104,8 +96,6 @@ class ConfigPage(QWidget):
 
         self.create_mask_layer.cfg_init()
         self.save_temp_images.cfg_init()
-        self.img2img_color_correct.cfg_init()
-        self.inpaint_color_correct.cfg_init()
         self.do_exact_steps.cfg_init()
         self.minimize_ui.cfg_init()
         self.alt_docker.cfg_init()
@@ -138,8 +128,6 @@ class ConfigPage(QWidget):
         self.create_mask_layer.cfg_connect()
         self.save_temp_images.cfg_connect()
         self.fix_aspect_ratio.cfg_connect()
-        self.img2img_color_correct.cfg_connect()
-        self.inpaint_color_correct.cfg_connect()
         self.do_exact_steps.cfg_connect()
         self.minimize_ui.cfg_connect()
         self.alt_docker.cfg_connect()

--- a/frontends/krita/krita_comfy/utils.py
+++ b/frontends/krita/krita_comfy/utils.py
@@ -198,11 +198,6 @@ def b64_to_img(enc: str):
     return QImage.fromData(ba) #Removed explicit format to support other image formats.
 
 
-def bytewise_xor(msg: bytes, key: bytes):
-    """Used for decrypting/encrypting request/response bodies."""
-    return bytes(v ^ k for v, k in zip(msg, cycle(key)))
-
-
 def clear_layout(layout: QLayout):
     if layout is not None:
         while layout.count():


### PR DESCRIPTION
Update links to this repo
Remove all the options from the Config page that are not used
- Remove XOR encryption due to TLS support.
- Move links to JasonS09 repo
- Remove un-used do_exact_steps
- Remove un-used no_groups 
- Remove un-used img2img_color_correct
- Remove un-used inpaint_color_correct
- Remove un-used include_grid
- Remove un-used only_full_img_tiling
- Remove un-used just_use_yaml
- Remove un-used nsfw